### PR TITLE
 Adding ClassBoundCacheContract 

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $classBoundCache = new ClassBoundCache($fileBoundCache);
 
 // Put the $myDataToCache object in cache.
 // If the FooBar class is modified, the cache item is purged.
-$classBoundCache->set('cache_key', $myDataToCache, FooBar::class);
+$classBoundCache->set('cache_key', $myDataToCache, new ReflectionClass(FooBar::class));
 
 // Fetching data
 $myDataToCache = $classBoundCache->get('cache_key');
@@ -88,3 +88,28 @@ use TheCodingMachine\CacheUtils\ClassBoundMemoryAdapter;
 
 $classBoundCache = new ClassBoundMemoryAdapter(new ClassBoundCache($psr16Cache));
 ```
+
+### Easier interface with cache contracts
+
+You can even get an easier to use class bound cache using the `ClassBoundCacheContract`.
+
+```php
+use TheCodingMachine\CacheUtils\FileBoundCache;
+use TheCodingMachine\CacheUtils\ClassBoundCache;
+use TheCodingMachine\CacheUtils\ClassBoundMemoryAdapter;
+use TheCodingMachine\CacheUtils\ClassBoundCacheContract;
+
+$fileBoundCache = new FileBoundCache($psr16Cache);
+$classBoundCache = new ClassBoundMemoryAdapter(new ClassBoundCache($psr16Cache));
+$classBoundCacheContract = new ClassBoundCacheContract(new ClassBoundCache($fileBoundCache));
+
+// Put the $myDataToCache object in cache.
+// If the FooBar class is modified, the cache item is purged.
+$classBoundCache->get(new ReflectionClass(FooBar::class), function() {
+    // let's return the item to be cached.
+    // this function is called only if the item is not in cache yet.
+});
+```
+
+With cache contracts, there is not setters. Only a getter that takes in parameter a callable that will resolve the 
+cache item if the item is not available in the cache.

--- a/src/ClassBoundCacheContract.php
+++ b/src/ClassBoundCacheContract.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 
 namespace TheCodingMachine\CacheUtils;
 
@@ -7,9 +8,7 @@ use ReflectionClass;
 
 class ClassBoundCacheContract implements ClassBoundCacheContractInterface
 {
-    /**
-     * @var ClassBoundCacheInterface
-     */
+    /** @var ClassBoundCacheInterface */
     private $classBoundCache;
 
     public function __construct(ClassBoundCacheInterface $classBoundCache)
@@ -18,14 +17,13 @@ class ClassBoundCacheContract implements ClassBoundCacheContractInterface
     }
 
     /**
-     * @param ReflectionClass $reflectionClass
-     * @param callable $resolver
-     * @param string|null $key An optional key to differentiate between cache items attached to the same class.
+     * @param string $key An optional key to differentiate between cache items attached to the same class.
+     *
      * @return mixed
      */
     public function get(ReflectionClass $reflectionClass, callable $resolver, string $key = '')
     {
-        $cacheKey = $reflectionClass->getName().'__'.$key;
+        $cacheKey = $reflectionClass->getName() . '__' . $key;
         $item = $this->classBoundCache->get($cacheKey);
         if ($item !== null) {
             return $item;

--- a/src/ClassBoundCacheContract.php
+++ b/src/ClassBoundCacheContract.php
@@ -1,0 +1,40 @@
+<?php
+
+
+namespace TheCodingMachine\CacheUtils;
+
+use ReflectionClass;
+
+class ClassBoundCacheContract implements ClassBoundCacheContractInterface
+{
+    /**
+     * @var ClassBoundCacheInterface
+     */
+    private $classBoundCache;
+
+    public function __construct(ClassBoundCacheInterface $classBoundCache)
+    {
+        $this->classBoundCache = $classBoundCache;
+    }
+
+    /**
+     * @param ReflectionClass $reflectionClass
+     * @param callable $resolver
+     * @param string|null $key An optional key to differentiate between cache items attached to the same class.
+     * @return mixed
+     */
+    public function get(ReflectionClass $reflectionClass, callable $resolver, string $key = '')
+    {
+        $cacheKey = $reflectionClass->getName().'__'.$key;
+        $item = $this->classBoundCache->get($cacheKey);
+        if ($item !== null) {
+            return $item;
+        }
+
+        $item = $resolver();
+
+        $this->classBoundCache->set($cacheKey, $item, $reflectionClass);
+
+        return $item;
+    }
+}

--- a/src/ClassBoundCacheContractInterface.php
+++ b/src/ClassBoundCacheContractInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace TheCodingMachine\CacheUtils;
+
+use ReflectionClass;
+
+interface ClassBoundCacheContractInterface
+{
+    /**
+     * @param ReflectionClass $reflectionClass
+     * @param callable $resolver
+     * @param string|null $key An optional key to differentiate between cache items attached to the same class.
+     * @return mixed
+     */
+    public function get(ReflectionClass $reflectionClass, callable $resolver, string $key = '');
+}

--- a/src/ClassBoundCacheContractInterface.php
+++ b/src/ClassBoundCacheContractInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TheCodingMachine\CacheUtils;
 
 use ReflectionClass;
@@ -7,9 +9,8 @@ use ReflectionClass;
 interface ClassBoundCacheContractInterface
 {
     /**
-     * @param ReflectionClass $reflectionClass
-     * @param callable $resolver
-     * @param string|null $key An optional key to differentiate between cache items attached to the same class.
+     * @param string $key An optional key to differentiate between cache items attached to the same class.
+     *
      * @return mixed
      */
     public function get(ReflectionClass $reflectionClass, callable $resolver, string $key = '');

--- a/tests/ClassBoundCacheContractTest.php
+++ b/tests/ClassBoundCacheContractTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace TheCodingMachine\CacheUtils;
+
+use function clearstatcache;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use function sleep;
+use Symfony\Component\Cache\Simple\ArrayCache;
+use TheCodingMachine\CacheUtils\Fixtures\A;
+use function touch;
+
+class ClassBoundCacheContractTest extends TestCase
+{
+    public function testClassBoundCacheContract()
+    {
+        $cache = new ArrayCache();
+        $fileBoundCache = new FileBoundCache($cache, 'prefix');
+        $classBoundCache = new ClassBoundCache($fileBoundCache, true, true, true);
+        $classBoundCacheContract = new ClassBoundCacheContract($classBoundCache);
+
+        $val = 0;
+
+        $newVal = $classBoundCacheContract->get(new ReflectionClass(A::class), function() use (&$val) {
+            return ++$val;
+        });
+
+        $this->assertSame(1, $newVal);
+
+        $newVal2 = $classBoundCacheContract->get(new ReflectionClass(A::class), function() use (&$val) {
+            return ++$val;
+        });
+
+        $this->assertSame(1, $newVal2);
+
+        $classToTouch = new ReflectionClass(A::class);
+        sleep(1);
+        clearstatcache($classToTouch->getFileName());
+        touch($classToTouch->getFileName());
+
+        $newVal3 = $classBoundCacheContract->get(new ReflectionClass(A::class), function() use (&$val) {
+            return ++$val;
+        });
+
+        $this->assertSame(2, $newVal3);
+    }
+
+}

--- a/tests/ClassBoundCacheTest.php
+++ b/tests/ClassBoundCacheTest.php
@@ -22,7 +22,7 @@ class ClassBoundCacheTest extends TestCase
     /**
      * @dataProvider touchFile
      */
-    public function testFileBoundCache($classToTouch)
+    public function testClassBoundCache($classToTouch)
     {
         $cache = new ArrayCache();
         $fileBoundCache = new FileBoundCache($cache, 'prefix');


### PR DESCRIPTION
ClassBoundCacheContract provides a developer friendly interface to fetch/set cache items related to a class automatically (using a unique getter that takes in parameter a resolver).