### PR TITLE
Switching to consuming PSR-6 instead of PSR-16

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,7 +1,7 @@
 build:
     environment:
         php:
-            version: 7.1
+            version: 7.3
     nodes:
         analysis:
             tests:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
 jobs:
   include:
     - stage: test
-      php: 7.3
+      php: 7.4
       env: PREFER_LOWEST=""
       before_script:
         - &composerupdate

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Why?
 
-This package contains a number of utility classes to play with PSR-16 caches.
+This package contains a number of utility classes to play with PSR-6 caches.
 
 ### File bound cache
 
@@ -23,7 +23,7 @@ sense to bind the cache invalidation to the modification date of the file. *thec
 ```php
 use TheCodingMachine\CacheUtils\FileBoundCache;
 
-$fileBoundCache = new FileBoundCache($psr16Cache);
+$fileBoundCache = new FileBoundCache($psr6Cache);
 
 // Put the $myDataToCache object in cache.
 // If 'FooBar.php' and 'FooBaz.php' are modified, the cache item is purged.
@@ -43,7 +43,7 @@ You can also use the `FileBoundMemoryAdapter` to store the cache in memory for e
 use TheCodingMachine\CacheUtils\FileBoundCache;
 use TheCodingMachine\CacheUtils\FileBoundMemoryAdapter;
 
-$fileBoundCache = new FileBoundMemoryAdapter(new FileBoundCache($psr16Cache));
+$fileBoundCache = new FileBoundMemoryAdapter(new FileBoundCache($psr6Cache));
 ```
 
 ### Class bound cache
@@ -55,7 +55,7 @@ The cache will expire if the class / trait / interface is modified.
 use TheCodingMachine\CacheUtils\FileBoundCache;
 use TheCodingMachine\CacheUtils\ClassBoundCache;
 
-$fileBoundCache = new FileBoundCache($psr16Cache);
+$fileBoundCache = new FileBoundCache($psr6Cache);
 $classBoundCache = new ClassBoundCache($fileBoundCache);
 
 // Put the $myDataToCache object in cache.
@@ -86,7 +86,7 @@ You can also use the `ClassBoundMemoryAdapter` to store the cache in memory for 
 use TheCodingMachine\CacheUtils\ClassBoundCache;
 use TheCodingMachine\CacheUtils\ClassBoundMemoryAdapter;
 
-$classBoundCache = new ClassBoundMemoryAdapter(new ClassBoundCache($psr16Cache));
+$classBoundCache = new ClassBoundMemoryAdapter(new ClassBoundCache($psr6Cache));
 ```
 
 ### Easier interface with cache contracts
@@ -99,8 +99,8 @@ use TheCodingMachine\CacheUtils\ClassBoundCache;
 use TheCodingMachine\CacheUtils\ClassBoundMemoryAdapter;
 use TheCodingMachine\CacheUtils\ClassBoundCacheContract;
 
-$fileBoundCache = new FileBoundCache($psr16Cache);
-$classBoundCache = new ClassBoundMemoryAdapter(new ClassBoundCache($psr16Cache));
+$fileBoundCache = new FileBoundCache($psr6Cache);
+$classBoundCache = new ClassBoundMemoryAdapter(new ClassBoundCache($psr6Cache));
 $classBoundCacheContract = new ClassBoundCacheContract(new ClassBoundCache($fileBoundCache));
 
 // If the FooBar class is modified, the cache item is purged.

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "psr/cache": "^1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5.9",
+        "phpunit/phpunit": "^8.5.3",
         "satooshi/php-coveralls": "^1.0",
         "symfony/cache": "^5.0.7",
         "phpstan/phpstan": "^0.12.18",

--- a/composer.json
+++ b/composer.json
@@ -11,16 +11,16 @@
     ],
     "require": {
         "php": ">=7.2",
-        "psr/simple-cache": "^1"
+        "psr/cache": "^1"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5.9",
         "satooshi/php-coveralls": "^1.0",
-        "symfony/cache": "^4.1.4",
-        "phpstan/phpstan": "^0.11",
-        "doctrine/coding-standard": "^6.0",
+        "symfony/cache": "^5.0.7",
+        "phpstan/phpstan": "^0.12.18",
+        "doctrine/coding-standard": "^7.0.2",
         "phpstan/extension-installer": "^1.0",
-        "thecodingmachine/phpstan-strict-rules": "^0.11.2"
+        "thecodingmachine/phpstan-strict-rules": "^0.12.0"
     },
     "autoload": {
         "psr-4": {
@@ -40,7 +40,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "2.0.x-dev"
         }
     }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -43,4 +43,10 @@
             <property name="spacesCountBeforeColon" value="0"/>
         </properties>
     </rule>
+
+    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
+        <properties>
+            <property name="enableNativeTypeHint" value="false"/>
+        </properties>
+    </rule>
 </ruleset>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,3 @@
 parameters:
     ignoreErrors:
-     - "#PHPDoc tag @throws with type Psr\\\\SimpleCache\\\\InvalidArgumentException is not subtype of Throwable#"
+     - '#PHPDoc tag @throws with type Psr\\Cache\\InvalidArgumentException is not subtype of Throwable#'

--- a/src/ClassBoundCache.php
+++ b/src/ClassBoundCache.php
@@ -9,14 +9,10 @@ use function array_merge;
 
 class ClassBoundCache implements ClassBoundCacheInterface
 {
-    /** @var FileBoundCacheInterface */
-    private $fileBoundCache;
-    /** @var bool */
-    private $analyzeParentClasses;
-    /** @var bool */
-    private $analyzeTraits;
-    /** @var bool */
-    private $analyzeInterfaces;
+    private FileBoundCacheInterface $fileBoundCache;
+    private bool $analyzeParentClasses;
+    private bool $analyzeTraits;
+    private bool $analyzeInterfaces;
 
     public function __construct(FileBoundCacheInterface $fileBoundCache, bool $analyzeParentClasses = true, bool $analyzeTraits = true, bool $analyzeInterfaces = false)
     {
@@ -40,7 +36,7 @@ class ClassBoundCache implements ClassBoundCacheInterface
      * Stores an item in the cache.
      *
      * @param mixed $item The item must be serializable.
-     * @param ReflectionClass $refClass If the class is modified, the cache item is invalidated.
+     * @param ReflectionClass<object> $refClass If the class is modified, the cache item is invalidated.
      */
     public function set(string $key, $item, ReflectionClass $refClass, ?int $ttl = null): void
     {
@@ -50,6 +46,8 @@ class ClassBoundCache implements ClassBoundCacheInterface
     }
 
     /**
+     * @param ReflectionClass<object> $refClass
+     *
      * @return array<int, string>
      */
     private function getFilesForClass(ReflectionClass $refClass): array

--- a/src/ClassBoundCache.php
+++ b/src/ClassBoundCache.php
@@ -9,10 +9,14 @@ use function array_merge;
 
 class ClassBoundCache implements ClassBoundCacheInterface
 {
-    private FileBoundCacheInterface $fileBoundCache;
-    private bool $analyzeParentClasses;
-    private bool $analyzeTraits;
-    private bool $analyzeInterfaces;
+    /** @var FileBoundCacheInterface */
+    private $fileBoundCache;
+    /** @var bool */
+    private $analyzeParentClasses;
+    /** @var bool */
+    private $analyzeTraits;
+    /** @var bool */
+    private $analyzeInterfaces;
 
     public function __construct(FileBoundCacheInterface $fileBoundCache, bool $analyzeParentClasses = true, bool $analyzeTraits = true, bool $analyzeInterfaces = false)
     {

--- a/src/ClassBoundCacheContract.php
+++ b/src/ClassBoundCacheContract.php
@@ -8,8 +8,7 @@ use ReflectionClass;
 
 class ClassBoundCacheContract implements ClassBoundCacheContractInterface
 {
-    /** @var ClassBoundCacheInterface */
-    private $classBoundCache;
+    private ClassBoundCacheInterface $classBoundCache;
 
     public function __construct(ClassBoundCacheInterface $classBoundCache)
     {
@@ -17,6 +16,7 @@ class ClassBoundCacheContract implements ClassBoundCacheContractInterface
     }
 
     /**
+     * @param ReflectionClass<object> $reflectionClass
      * @param string $key An optional key to differentiate between cache items attached to the same class.
      *
      * @return mixed

--- a/src/ClassBoundCacheContract.php
+++ b/src/ClassBoundCacheContract.php
@@ -8,7 +8,8 @@ use ReflectionClass;
 
 class ClassBoundCacheContract implements ClassBoundCacheContractInterface
 {
-    private ClassBoundCacheInterface $classBoundCache;
+    /** @var ClassBoundCacheInterface */
+    private $classBoundCache;
 
     public function __construct(ClassBoundCacheInterface $classBoundCache)
     {

--- a/src/ClassBoundCacheContractInterface.php
+++ b/src/ClassBoundCacheContractInterface.php
@@ -9,6 +9,7 @@ use ReflectionClass;
 interface ClassBoundCacheContractInterface
 {
     /**
+     * @param ReflectionClass<object> $reflectionClass
      * @param string $key An optional key to differentiate between cache items attached to the same class.
      *
      * @return mixed

--- a/src/ClassBoundCacheInterface.php
+++ b/src/ClassBoundCacheInterface.php
@@ -22,7 +22,7 @@ interface ClassBoundCacheInterface
      * Stores an item in the cache.
      *
      * @param mixed $item The item must be serializable.
-     * @param ReflectionClass $refClass If the class is modified, the cache item is invalidated.
+     * @param ReflectionClass<object> $refClass If the class is modified, the cache item is invalidated.
      */
     public function set(string $key, $item, ReflectionClass $refClass, ?int $ttl = null): void;
 }

--- a/src/ClassBoundMemoryAdapter.php
+++ b/src/ClassBoundMemoryAdapter.php
@@ -12,8 +12,9 @@ use ReflectionClass;
 class ClassBoundMemoryAdapter implements ClassBoundCacheInterface
 {
     /** @var array<string, mixed> */
-    private array $items;
-    private ClassBoundCacheInterface $classBoundCache;
+    private $items;
+    /** @var ClassBoundCacheInterface */
+    private $classBoundCache;
 
     public function __construct(ClassBoundCacheInterface $classBoundCache)
     {

--- a/src/ClassBoundMemoryAdapter.php
+++ b/src/ClassBoundMemoryAdapter.php
@@ -12,9 +12,8 @@ use ReflectionClass;
 class ClassBoundMemoryAdapter implements ClassBoundCacheInterface
 {
     /** @var array<string, mixed> */
-    private $items;
-    /** @var ClassBoundCacheInterface */
-    private $classBoundCache;
+    private array $items;
+    private ClassBoundCacheInterface $classBoundCache;
 
     public function __construct(ClassBoundCacheInterface $classBoundCache)
     {
@@ -39,7 +38,7 @@ class ClassBoundMemoryAdapter implements ClassBoundCacheInterface
      * Stores an item in the cache.
      *
      * @param mixed $item The item must be serializable.
-     * @param ReflectionClass $refClass If the class is modified, the cache item is invalidated.
+     * @param ReflectionClass<object> $refClass If the class is modified, the cache item is invalidated.
      */
     public function set(string $key, $item, ReflectionClass $refClass, ?int $ttl = null): void
     {

--- a/src/FileBoundCache.php
+++ b/src/FileBoundCache.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace TheCodingMachine\CacheUtils;
 
 use Psr\Cache\CacheItemPoolInterface;
-use Psr\SimpleCache\InvalidArgumentException;
+use Psr\Cache\InvalidArgumentException;
 use function filemtime;
 use function str_replace;
 
 class FileBoundCache implements FileBoundCacheInterface
 {
-    /** @var CacheInterface */
+    /** @var CacheItemPoolInterface */
     private $cache;
     /** @var string */
     private $cachePrefix;

--- a/src/FileBoundCache.php
+++ b/src/FileBoundCache.php
@@ -4,23 +4,21 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\CacheUtils;
 
-use Psr\SimpleCache\CacheInterface;
+use Psr\Cache\CacheItemPoolInterface;
 use Psr\SimpleCache\InvalidArgumentException;
 use function filemtime;
 use function str_replace;
 
 class FileBoundCache implements FileBoundCacheInterface
 {
-    /** @var CacheInterface */
-    private $cache;
-    /** @var string */
-    private $cachePrefix;
+    private CacheItemPoolInterface $cache;
+    private string $cachePrefix;
 
     /**
-     * @param CacheInterface $cache The underlying cache system.
+     * @param CacheItemPoolInterface $cache The underlying PSR-6 cache system.
      * @param string $cachePrefix The prefix to add to the cache.
      */
-    public function __construct(CacheInterface $cache, string $cachePrefix = '')
+    public function __construct(CacheItemPoolInterface $cache, string $cachePrefix = '')
     {
         $this->cache = $cache;
         $this->cachePrefix = str_replace(['\\', '{', '}', '(', ')', '/', '@', ':'], '_', $cachePrefix);
@@ -37,12 +35,12 @@ class FileBoundCache implements FileBoundCacheInterface
      */
     public function get(string $key, $default = null)
     {
-        $item = $this->cache->get($this->cachePrefix . str_replace(['\\', '{', '}', '(', ')', '/', '@', ':'], '_', $key));
-        if ($item !== null) {
+        $item = $this->cache->getItem($this->cachePrefix . str_replace(['\\', '{', '}', '(', ')', '/', '@', ':'], '_', $key));
+        if ($item->isHit()) {
             [
                 'files' => $files,
                 'data' => $data,
-            ] = $item;
+            ] = $item->get();
 
             $expired = false;
             foreach ($files as $fileName => $fileMTime) {
@@ -74,12 +72,16 @@ class FileBoundCache implements FileBoundCacheInterface
             if ($fileMTime === false) {
                 throw FileAccessException::cannotAccessFileModificationTime($fileName);
             }
+
             $files[$fileName] = $fileMTime;
         }
 
-        $this->cache->set($this->cachePrefix . str_replace(['\\', '{', '}', '(', ')', '/', '@', ':'], '_', $key), [
+        $cacheItem = $this->cache->getItem($this->cachePrefix . str_replace(['\\', '{', '}', '(', ')', '/', '@', ':'], '_', $key));
+        $cacheItem->set([
             'files' => $files,
             'data' => $item,
-        ], $ttl);
+        ]);
+        $cacheItem->expiresAfter($ttl);
+        $this->cache->save($cacheItem);
     }
 }

--- a/src/FileBoundCache.php
+++ b/src/FileBoundCache.php
@@ -11,8 +11,10 @@ use function str_replace;
 
 class FileBoundCache implements FileBoundCacheInterface
 {
-    private CacheItemPoolInterface $cache;
-    private string $cachePrefix;
+    /** @var CacheInterface */
+    private $cache;
+    /** @var string */
+    private $cachePrefix;
 
     /**
      * @param CacheItemPoolInterface $cache The underlying PSR-6 cache system.

--- a/src/FileBoundMemoryAdapter.php
+++ b/src/FileBoundMemoryAdapter.php
@@ -10,9 +10,8 @@ namespace TheCodingMachine\CacheUtils;
 class FileBoundMemoryAdapter implements FileBoundCacheInterface
 {
     /** @var array<string, mixed> */
-    private $items;
-    /** @var FileBoundCacheInterface */
-    private $fileBoundCache;
+    private array $items;
+    private FileBoundCacheInterface $fileBoundCache;
 
     public function __construct(FileBoundCacheInterface $fileBoundCache)
     {

--- a/src/FileBoundMemoryAdapter.php
+++ b/src/FileBoundMemoryAdapter.php
@@ -10,8 +10,9 @@ namespace TheCodingMachine\CacheUtils;
 class FileBoundMemoryAdapter implements FileBoundCacheInterface
 {
     /** @var array<string, mixed> */
-    private array $items;
-    private FileBoundCacheInterface $fileBoundCache;
+    private $items;
+    /** @var FileBoundCacheInterface */
+    private $fileBoundCache;
 
     public function __construct(FileBoundCacheInterface $fileBoundCache)
     {

--- a/tests/ClassBoundCacheContractTest.php
+++ b/tests/ClassBoundCacheContractTest.php
@@ -13,7 +13,7 @@ use function touch;
 
 class ClassBoundCacheContractTest extends TestCase
 {
-    public function testClassBoundCacheContract()
+    public function testClassBoundCacheContract(): void
     {
         $cache = new ArrayAdapter();
         $fileBoundCache = new FileBoundCache($cache, 'prefix');

--- a/tests/ClassBoundCacheContractTest.php
+++ b/tests/ClassBoundCacheContractTest.php
@@ -2,6 +2,7 @@
 
 namespace TheCodingMachine\CacheUtils;
 
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use function clearstatcache;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
@@ -14,7 +15,7 @@ class ClassBoundCacheContractTest extends TestCase
 {
     public function testClassBoundCacheContract()
     {
-        $cache = new ArrayCache();
+        $cache = new ArrayAdapter();
         $fileBoundCache = new FileBoundCache($cache, 'prefix');
         $classBoundCache = new ClassBoundCache($fileBoundCache, true, true, true);
         $classBoundCacheContract = new ClassBoundCacheContract($classBoundCache);

--- a/tests/ClassBoundCacheTest.php
+++ b/tests/ClassBoundCacheTest.php
@@ -23,7 +23,7 @@ class ClassBoundCacheTest extends TestCase
     /**
      * @dataProvider touchFile
      */
-    public function testClassBoundCache($classToTouch)
+    public function testClassBoundCache($classToTouch): void
     {
         $cache = new ArrayAdapter();
         $fileBoundCache = new FileBoundCache($cache, 'prefix');

--- a/tests/ClassBoundCacheTest.php
+++ b/tests/ClassBoundCacheTest.php
@@ -2,6 +2,7 @@
 
 namespace TheCodingMachine\CacheUtils;
 
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use function clearstatcache;
 use function file_get_contents;
 use function file_put_contents;
@@ -24,7 +25,7 @@ class ClassBoundCacheTest extends TestCase
      */
     public function testClassBoundCache($classToTouch)
     {
-        $cache = new ArrayCache();
+        $cache = new ArrayAdapter();
         $fileBoundCache = new FileBoundCache($cache, 'prefix');
         $classBoundCache = new ClassBoundCache($fileBoundCache, true, true, true);
 

--- a/tests/ClassBoundMemoryAdapterTest.php
+++ b/tests/ClassBoundMemoryAdapterTest.php
@@ -2,6 +2,7 @@
 
 namespace TheCodingMachine\CacheUtils;
 
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use function clearstatcache;
 use function file_get_contents;
 use function file_put_contents;
@@ -18,7 +19,7 @@ class ClassBoundMemoryAdapterTest extends TestCase
 {
     public function testMemory()
     {
-        $cache = new ArrayCache();
+        $cache = new ArrayAdapter();
         $fileBoundCache = new FileBoundCache($cache, 'prefix');
         $classBoundCache = new ClassBoundCache($fileBoundCache);
         $adapter = new ClassBoundMemoryAdapter($classBoundCache);

--- a/tests/ClassBoundMemoryAdapterTest.php
+++ b/tests/ClassBoundMemoryAdapterTest.php
@@ -17,7 +17,7 @@ use function touch;
 
 class ClassBoundMemoryAdapterTest extends TestCase
 {
-    public function testMemory()
+    public function testMemory(): void
     {
         $cache = new ArrayAdapter();
         $fileBoundCache = new FileBoundCache($cache, 'prefix');

--- a/tests/FileBoundCacheTest.php
+++ b/tests/FileBoundCacheTest.php
@@ -2,6 +2,7 @@
 
 namespace TheCodingMachine\CacheUtils;
 
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use function clearstatcache;
 use function file_get_contents;
 use function file_put_contents;
@@ -15,7 +16,7 @@ class FileBoundCacheTest extends TestCase
 {
     public function testFileBoundCache()
     {
-        $cache = new ArrayCache();
+        $cache = new ArrayAdapter();
         $fileBoundCache = new FileBoundCache($cache, 'prefix');
 
         $tmpPath = sys_get_temp_dir().'/tmpCacheTest';
@@ -36,7 +37,7 @@ class FileBoundCacheTest extends TestCase
 
     public function testException()
     {
-        $cache = new ArrayCache();
+        $cache = new ArrayAdapter();
         $fileBoundCache = new FileBoundCache($cache, 'prefix');
 
         $this->expectException(FileAccessException::class);

--- a/tests/FileBoundCacheTest.php
+++ b/tests/FileBoundCacheTest.php
@@ -14,7 +14,7 @@ use function touch;
 
 class FileBoundCacheTest extends TestCase
 {
-    public function testFileBoundCache()
+    public function testFileBoundCache(): void
     {
         $cache = new ArrayAdapter();
         $fileBoundCache = new FileBoundCache($cache, 'prefix');
@@ -35,7 +35,7 @@ class FileBoundCacheTest extends TestCase
         $this->assertNull($fileBoundCache->get('foo'));
     }
 
-    public function testException()
+    public function testException(): void
     {
         $cache = new ArrayAdapter();
         $fileBoundCache = new FileBoundCache($cache, 'prefix');

--- a/tests/FileBoundMemoryAdapterTest.php
+++ b/tests/FileBoundMemoryAdapterTest.php
@@ -2,6 +2,7 @@
 
 namespace TheCodingMachine\CacheUtils;
 
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use function clearstatcache;
 use function file_get_contents;
 use function file_put_contents;
@@ -16,7 +17,7 @@ class FileBoundMemoryAdapterTest extends TestCase
 {
     public function testMemory()
     {
-        $cache = new ArrayCache();
+        $cache = new ArrayAdapter();
         $fileBoundCache = new FileBoundCache($cache, 'prefix');
         $adapter = new FileBoundMemoryAdapter($fileBoundCache);
 

--- a/tests/FileBoundMemoryAdapterTest.php
+++ b/tests/FileBoundMemoryAdapterTest.php
@@ -15,7 +15,7 @@ use function touch;
 
 class FileBoundMemoryAdapterTest extends TestCase
 {
-    public function testMemory()
+    public function testMemory(): void
     {
         $cache = new ArrayAdapter();
         $fileBoundCache = new FileBoundCache($cache, 'prefix');


### PR DESCRIPTION
This is a breaking change that will trigger a V2.
Symfony and Laravel provide out of the box PSR-6 caches so it makes sense to target PSR-6 that seems to getting some leverage.