### PR TITLE
allow never psr/cache dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.2",
-        "psr/cache": "^1"
+        "psr/cache": "^1|^2|^3"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5.3",


### PR DESCRIPTION
This dependency is holding our project from using graphqlite
I don't think any compatibility-breaking changes were made to psr/cache.